### PR TITLE
Fixed workflow

### DIFF
--- a/.github/workflows/twitter-together.yml
+++ b/.github/workflows/twitter-together.yml
@@ -12,9 +12,9 @@ jobs:
   tweet:
     name: Tweet
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
-      - name: checkout main
+      - name: checkout master
         uses: actions/checkout@v3
       - name: Tweet
         uses: twitter-together/action@v3


### PR DESCRIPTION
The workflow is referencing 'main' when the default branch is named 'master'.