### PR TITLE
Updated workflow permissions

### DIFF
--- a/.github/workflows/twitter-together.yml
+++ b/.github/workflows/twitter-together.yml
@@ -10,6 +10,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   tweet:
+    permissions: write-all
     name: Tweet
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'


### PR DESCRIPTION
This commit is only required if the `tweet` job results in the following error:

```
Running twitter-together version 2.1.2
Tweeting: <message>
tweeted: <url>
HttpError: Resource not accessible by integration
Error: HttpError: Resource not accessible by integration
```