### PR TITLE
Fix Create New Tweet URL

### DIFF
--- a/tweets/README.md
+++ b/tweets/README.md
@@ -2,7 +2,7 @@
 
 To create a new tweet create a new `*.tweet` file in this `tweets/` folder.
 
-<kbd>[Create new tweet](../../../new/main/?filename=tweets/<your-path>.tweet)</kbd>
+<kbd>[Create new tweet](../../../new/master/?filename=tweets/<your-path>.tweet)</kbd>
 
 ## Example
 


### PR DESCRIPTION
@Sol-Sanctum updated `main` to `master` which broke the create new tweet link. This PR fixes that.